### PR TITLE
Collection export bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A SaaS vendor audio/video repository solution. Terminology:
 
 **Note:** pagination is not documented (as of 2023-05-29) so workarounds are needed for collections with more than 100 resources (e.g., use Web UI export to gain a list of IDs)
 
-**Note:** as of 2023-06-29, a resource returned by the Aviary API lists the attached media item(s) in the `media_file_id` field. However, `media_ife_id` only contains a maximum of 10 IDs (a significant number of resources have over 10 media attached). I also tried via the Web UI, "export Media Files(s) to CSV" but the resulting file doesn't contain media IDs. How to get the entire list of media items is unknown.
+**Note:** as of 2023-06-29, a resource returned by the Aviary API lists the attached media item(s) in the `media_file_id` field. However, `media_file_id` only contains a maximum of 10 IDs (a significant number of resources have over 10 media attached). I also tried via the Web UI, "export Media Files(s) to CSV" but the resulting file doesn't contain media IDs. How to get the entire list of media items is unknown.
 
 ## Included Scripts
 
@@ -91,6 +91,10 @@ python3 experimental/aviary_api_report_resources_csv.py --server ${aviary_server
 ```
 
 For a JSON-like output (more for debugging)
+
+[JSON](./json/)
+
+Or
 
 ``` bash
 python3 experimental/aviary_api_report_resources_json.py --server ${aviary_server_name} --output ${output_path}
@@ -156,6 +160,8 @@ Note: `experiemental/aviary_api_report_transcripts_csv_by_list.py` uses the reso
 python3 aviary_api_report_index_csv_by_media_list.py --server ${aviary_server_name} --output ${output_path} -input ${input_path}
 ```
 
+Or [JSON](./json/)
+
 **Note:** the resource API response, when the `media files count` is >10, the `media file IDs` will display only a maximum of 10 IDs in the list (as of May 2023). An example is resource 58924
 
 Todo: alter to remove the need for an input file of ID once pagination is available and replace with `/api/v1/collections` and `/api/v1/collections/{:collection_id}/resources` to build a list of media.
@@ -208,7 +214,7 @@ ffmpeg -f concat -safe 0 -i ffmpeg_concat.txt -c copy 3g.mp4
 To check style:
 
 ``` bash
-pycodestyle --show-source --show-pep8 --ignore=E402,W504 --max-line-length=200 . 
+pycodestyle --show-source --show-pep8 --ignore=E402,W504 --max-line-length=200 .
 ```
 
 To run tests:

--- a/aviary/api.py
+++ b/aviary/api.py
@@ -207,7 +207,7 @@ def get_transcripts_item(args, session, id):
     return response.content
 
 
-# A GET is not supported as of 2023-05-26; see https://www.aviaryplatform.com/api/v1/documentation#Indexes
+# The HTTP GET request is not supported as of 2023-05-26; see https://www.aviaryplatform.com/api/v1/documentation#Indexes
 # The following is a workaround - id is the media id as the media APi includes the index json
 def get_indexes_item(args, session, id):
     # response = session.get(
@@ -222,6 +222,16 @@ def get_indexes_item(args, session, id):
         return media_json['data']['indexes']
     else:
         logging.error(f"media id:[{id}] - {media_json}")
+
+# The GET HTTP request may now be supported: 2024-03-25
+def get_indexes_item_v2(args, session, id):
+    response = session.get(
+        urljoin(args.server, 'api/v1/indexes/' + str(id))
+    )
+    logging.info(f"{response.request.url}")
+    # print(response.__dict__)
+    # print(response.content)
+    return response.content
 
 #
 def get_supplemental_files_item(args, session, id):

--- a/experimental/experimental_test_batch_download.py
+++ b/experimental/experimental_test_batch_download.py
@@ -1,6 +1,6 @@
 ##############################################################################################
 # desc: exploratory script to download files attached to Aviary content (audio/video, transcripts, index, and supplemental files)
-#       exploritory / proof-of-concept code
+#       exploratory / proof-of-concept code
 # usage:
 #       python3 experimental/experimental_download.py --server ${SERVER_URL}  --id ${ID} --type ${TYPE}
 #       python3 experimental/experimental_download.py --server ${SERVER_URL}  --id 53122 --type i

--- a/json/README.md
+++ b/json/README.md
@@ -1,0 +1,14 @@
+# JSON Output
+
+A set of scripts based on the CSV output versions of similar names but adapted to output JSON.
+
+Note: Nov. 2023, due to a lack of pagination within the AVP Aviary API documentation (and a limit of the first 100 results with the remainder cutoff), a workaround is used by the script that involves exporting from the admin resource/media/etc. table view in the UI (see comments at the top of the script for details).
+
+## Resources in JSON via the UI-generated resource list
+
+* `aviary_api_report_resources_json_by_resource_list.py`
+
+## Indexes in JSON via the UI-generated resource list
+
+* `aviary_api_report_index_json_by_media_list.py`
+* requires the UI-generated media list which contains the metadata for the attached index content type (i.e., `index` content type is attached to a specified `media`) content type

--- a/json/README.md
+++ b/json/README.md
@@ -8,7 +8,22 @@ Note: Nov. 2023, due to a lack of pagination within the AVP Aviary API documenta
 
 * `aviary_api_report_resources_json_by_resource_list.py`
 
-## Indexes in JSON via the UI-generated resource list
+## Indexes in JSON via the UI-generated media list
 
 * `aviary_api_report_index_json_by_media_list.py`
 * requires the UI-generated media list which contains the metadata for the attached index content type (i.e., `index` content type is attached to a specified `media`) content type
+
+## Media in JSON from Resource JSON
+
+* Given input from `aviary_api_report_resources_json_by_resource_list.py`, output the associated Media JSON
+* `aviary_api_report_media_by_resource_json.py`
+
+## Indexes in JSON via a Media JSON
+
+* Given input from `aviary_api_report_media_by_resource_json.py`, output the associated Indexes JSON
+* `aviary_api_report_index_by_media_json.py`
+
+## Download the attached file to an Index
+
+* Given input from `aviary_api_report_index_by_media_json.py`, output the file attached to the Indexes
+* `aviary_api_download_index_by_index_json.py`

--- a/json/aviary_api_download_index_by_index_json.py
+++ b/json/aviary_api_download_index_by_index_json.py
@@ -1,9 +1,9 @@
 ##############################################################################################
-# desc: connect to the Aviary API and get index item metadata
-#       output: JSON
-#       input: Media JSON from the aviary_api_report_media_by_resource_json.py (API limits number of results from the collection resource listing API call with no pagination information 2023-03-27)
+# desc: connect to the Aviary API and download index file
+#       output_path: directory path to store downloaded files
+#       input: Indexes JSON from the aviary_api_report_index_by_media_json.py (API limits number of results from the collection resource listing API call with no pagination information 2023-03-27)
 #       exploratory / proof-of-concept code
-# usage: python3 aviary_api_report_index_by_media_json.py.py \
+# usage: python3 aviary_api_download_index_by_index_json.py \
 #           --server ${aviary_server_name} --output ${output_path} -input ${input_path}
 # license: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication
 # date: March, 2024
@@ -28,32 +28,41 @@ from aviary import utilities as aviaryUtilities
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument('--server', required=True, help='Server name.')
-    parser.add_argument('--output', required=True, help='Location to store output file.')
-    parser.add_argument('--input', required=True, help='List of IDs to add to the report.')
+    parser.add_argument('--output_path', required=True, help='Location to store output file.')
+    parser.add_argument('--input', required=True, help='JSON output from index API.')
     parser.add_argument('--wait', required=False, help='Time to wait between API calls.', default=1)
     parser.add_argument('--logging_level', required=False, help='Logging level.', default=logging.WARNING)
     return parser.parse_args()
 
 
 #
-def process(args, session, input_json, output_file):
+def process(args, session, input_json):
 
     # hold json in memory
     data = []
-    for i, media in enumerate(input_json):
-        logging.info(f"{media['data']['indexes']}")
-        for j, index in enumerate(media['data']['indexes']):
-            try:
-                item = aviaryApi.get_indexes_item_v2(args, session, index['id'])
-                data.append(json.loads(item))
-            except BaseException as e:
-                logging.error(f"{e} \n{index}")
-                # add a line to the CSV output with the error
-            if j >= 10:
-                logging.warning(f"Check number of media files - this workaround may miss items as 'media_file_id' property may limit to only 10.\n{item}")
-            sleep(int(args.wait))
+    for i, index in enumerate(input_json):
+        try:
+            logging.info(f"{index['data']['id']} {index['data']['export']['file']} {index['data']['export']['file_name']}")
+
+            if ( index['data']['export']['file_name'] ) :
+                file_name = index['data']['export']['file_name']
+            else :
+                file_name = f"{index['data']['id']}.webvtt"
+
+            logging.info(f"{file_name} {index['data']['export']['file_content_type']}")
+
+            aviaryUtilities.download_file(
+                session,
+                index['data']['export']['file'],
+                file_name,
+                path=args.output_path,
+                headers={}
+                )
+        except BaseException as e:
+            logging.error(f"{e} \n{index}")
+            # add a line to the CSV output with the error
+        sleep(int(args.wait))
         aviaryUtilities.progressIndicator(i, args.logging_level)
-    output_file.write(json.dumps(data))
     print(f"\nItems processed: {i + 1}")
 
 
@@ -68,8 +77,7 @@ def main():
 
     with open(args.input, 'r', newline='') as input_file:
         input_json = json.load(input_file)
-        with open(args.output, 'wt', encoding="utf-8", newline='') as output_file:
-            process(args, session, input_json, output_file)
+        process(args, session, input_json)
 
 
 if __name__ == "__main__":

--- a/json/aviary_api_report_index_by_media_json.py
+++ b/json/aviary_api_report_index_by_media_json.py
@@ -1,9 +1,9 @@
 ##############################################################################################
-# desc: connect to the Aviary API and get media item metadata
+# desc: connect to the Aviary API and get index item metadata
 #       output: JSON
-#       input: CSV from the Aviary web UI resource export (API limits number of results from the collection resource listing API call with no pagination information 2023-03-27)
-#       exploritory / proof-of-concept code
-# usage: python3 aviary_api_report_resources_json_by_resource_list.py \
+#       input: JSON from the aviary_api_report_media_by_resource_json.py (API limits number of results from the collection resource listing API call with no pagination information 2023-03-27)
+#       exploratory / proof-of-concept code
+# usage: python3 aviary_api_report_index_by_media_json.py.py \
 #           --server ${aviary_server_name} --output ${output_path} -input ${input_path}
 # license: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication
 # date: Nov, 2023
@@ -27,30 +27,34 @@ from aviary import utilities as aviaryUtilities
 
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--server', required=True, help='Servername.')
+    parser.add_argument('--server', required=True, help='Server name.')
     parser.add_argument('--output', required=True, help='Location to store output file.')
     parser.add_argument('--input', required=True, help='List of resource IDs to add to the report.')
-    parser.add_argument('--wait', required=False, help='Time to wait between API calls.', default=0.1)
+    parser.add_argument('--wait', required=False, help='Time to wait between API calls.', default=1)
     parser.add_argument('--logging_level', required=False, help='Logging level.', default=logging.WARNING)
     return parser.parse_args()
 
 
 #
-def process(args, session, input_csv, output_file):
+def process(args, session, input_json, output_file):
 
     # hold json in memory
     data = []
     # should use the following but the documentation doesn't include pagination details
     # aviaryApi.get_collection_list(args, session)
     # aviaryApi.get_collection_resources(args, session, collection['id'])
-    for i, resource in enumerate(input_csv):
-        try:
-            item = aviaryApi.get_resource_item(args, session, resource['aviary ID'])
-            data.append(json.loads(item))
-        except BaseException as e:
-            logging.error(f"{e} \n{resource}")
-            # add a line to the CSV output with the error
-        sleep(args.wait)
+    for i, resource in enumerate(input_json):
+        logging.info(f"{resource['data']['indexes']}")
+        for j, index in enumerate(resource['data']['indexes']):
+            try:
+                item = aviaryApi.get_indexes_item_v2(args, session, index['id'])
+                data.append(json.loads(item))
+            except BaseException as e:
+                logging.error(f"{e} \n{index}")
+                # add a line to the CSV output with the error
+            if j >= 10:
+                logging.warning(f"Check number of media files - this workaround may miss items as 'media_file_id' property may limit to only 10.\n{item}")
+            sleep(args.wait)
         aviaryUtilities.progressIndicator(i, args.logging_level)
     output_file.write(json.dumps(data))
     print(f"\nItems processed: {i + 1}")
@@ -65,10 +69,10 @@ def main():
 
     session = aviaryApi.init_session(args, username, password)
 
-    with open(args.input, 'r', encoding="utf-8", newline='') as input_file:
-        input_csv = csv.DictReader(input_file)
+    with open(args.input, 'r', newline='') as input_file:
+        input_json = json.load(input_file)
         with open(args.output, 'wt', encoding="utf-8", newline='') as output_file:
-            process(args, session, input_csv, output_file)
+            process(args, session, input_json, output_file)
 
 
 if __name__ == "__main__":

--- a/json/aviary_api_report_index_json_by_media_list.py
+++ b/json/aviary_api_report_index_json_by_media_list.py
@@ -1,8 +1,8 @@
 ##############################################################################################
 # desc: connect to the Aviary API and get index item metadata
-#       output: CSV
+#       output: JSON
 #       input: CSV from the Aviary web UI media export (API limits number of results from the collection resource listing API call with no pagination information 2023-03-27)
-#       exploritory / proof-of-concept code
+#       exploratory / proof-of-concept code
 # usage: python3 aviary_api_report_index_csv_by_media_list.py \
 #           --server ${aviary_server_name} --output ${output_path} -input ${input_path}
 # license: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication

--- a/json/aviary_api_report_index_json_by_media_list.py
+++ b/json/aviary_api_report_index_json_by_media_list.py
@@ -1,0 +1,89 @@
+##############################################################################################
+# desc: connect to the Aviary API and get index item metadata
+#       output: CSV
+#       input: CSV from the Aviary web UI media export (API limits number of results from the collection resource listing API call with no pagination information 2023-03-27)
+#       exploritory / proof-of-concept code
+# usage: python3 aviary_api_report_index_csv_by_media_list.py \
+#           --server ${aviary_server_name} --output ${output_path} -input ${input_path}
+# license: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication
+# date: June 15, 2022
+##############################################################################################
+
+# Proof-of-concept only
+
+from getpass import getpass
+from time import sleep
+import argparse
+import csv
+import json
+import logging
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from aviary import api as aviaryApi
+from aviary import utilities as aviaryUtilities
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--server', required=True, help='Servername.')
+    parser.add_argument('--output', required=True, help='Location to store output file.')
+    parser.add_argument('--input', required=True, help='List of media IDs to add to the report.')
+    parser.add_argument('--wait', required=False, help='Time to wait between API calls.', default=0.1)
+    parser.add_argument('--logging_level', required=False, help='Logging level.', default=logging.WARNING)
+    return parser.parse_args()
+
+
+#
+def process(args, session, input_csv, output_file):
+
+    # is there a better way then to hold all JSON in memory before writing?
+    data = []
+
+    # Todo: redo once upstream API documents pagination
+    # Iterate through the media / resource / collection list
+    for i, row in enumerate(input_csv):
+        media_id = row['aviary ID']
+        media = aviaryApi.get_media_item(args, session, media_id)
+        media_json = json.loads(media)
+        if ('data' in media_json):
+            tmp = {
+                'Collection title': row['Collection Title'],
+                'Linked resource ID': row['Linked Resource Id'],
+                'Linked resource title': row['Linked Resource Title'],
+                'media_file_id': media_id,
+                'indexes': []
+            }
+            for index in media_json['data']['indexes']:
+                # Todo: this fails due to the API not supporting the call
+                # for indexes_id in media_json['data']['indexes'] :
+                # index = aviaryApi.get_indexes_item(args, session, indexes_id)
+                tmp['indexes'].append(index)
+                logging.info(index)
+            data.append(tmp)
+        else:
+            logging.error(f"media id:[{media_id}] - {media_json}")
+        aviaryUtilities.progressIndicator(i, args.logging_level)
+        sleep(int(args.wait))
+    output_file.write(json.dumps(data))
+    print(f"\nMedia Items processed looking for attached index: {i + 1}")
+
+
+#
+def main():
+    args = parse_args()
+
+    username = input('Username:')
+    password = getpass('Password:')
+
+    session = aviaryApi.init_session(args, username, password)
+
+    with open(args.input, 'r', encoding="utf-8", newline='') as input_file:
+        input_csv = csv.DictReader(input_file)
+        with open(args.output, 'wt', encoding="utf-8", newline='') as output_file:
+            process(args, session, input_csv, output_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/json/aviary_api_report_media_by_resource_json.py
+++ b/json/aviary_api_report_media_by_resource_json.py
@@ -1,12 +1,12 @@
 ##############################################################################################
 # desc: connect to the Aviary API and get media item metadata
 #       output: JSON
-#       input: JSON from the aviary_api_report_media_by_resource_json.py (API limits number of results from the collection resource listing API call with no pagination information 2023-03-27)
+#       input: Resource JSON from the aviary_api_report_resources_json_by_resource_list.py (API limits number of results from the collection resource listing API call with no pagination information 2023-03-27)
 #       exploratory / proof-of-concept code
-# usage: python3 aviary_api_report_media_by_resource_json.py.py \
+# usage: python3 aviary_api_report_media_by_resource_json.py \
 #           --server ${aviary_server_name} --output ${output_path} -input ${input_path}
 # license: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication
-# date: Nov, 2023
+# date: March, 2024
 ##############################################################################################
 
 # Proof-of-concept only
@@ -54,7 +54,7 @@ def process(args, session, input_json, output_file):
                 # add a line to the CSV output with the error
             if j >= 10:
                 logging.warning(f"Check number of media files - this workaround may miss items as 'media_file_id' property may limit to only 10.\n{item}")
-            sleep(args.wait)
+            sleep(iint(args.wait))
         aviaryUtilities.progressIndicator(i, args.logging_level)
     output_file.write(json.dumps(data))
     print(f"\nItems processed: {i + 1}")

--- a/json/aviary_api_report_media_by_resource_json.py
+++ b/json/aviary_api_report_media_by_resource_json.py
@@ -1,9 +1,9 @@
 ##############################################################################################
 # desc: connect to the Aviary API and get media item metadata
 #       output: JSON
-#       input: CSV from the Aviary web UI resource export (API limits number of results from the collection resource listing API call with no pagination information 2023-03-27)
-#       exploritory / proof-of-concept code
-# usage: python3 aviary_api_report_resources_json_by_resource_list.py \
+#       input: JSON from the aviary_api_report_media_by_resource_json.py (API limits number of results from the collection resource listing API call with no pagination information 2023-03-27)
+#       exploratory / proof-of-concept code
+# usage: python3 aviary_api_report_media_by_resource_json.py.py \
 #           --server ${aviary_server_name} --output ${output_path} -input ${input_path}
 # license: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication
 # date: Nov, 2023
@@ -27,7 +27,7 @@ from aviary import utilities as aviaryUtilities
 
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--server', required=True, help='Servername.')
+    parser.add_argument('--server', required=True, help='Server name.')
     parser.add_argument('--output', required=True, help='Location to store output file.')
     parser.add_argument('--input', required=True, help='List of resource IDs to add to the report.')
     parser.add_argument('--wait', required=False, help='Time to wait between API calls.', default=0.1)
@@ -36,21 +36,25 @@ def parse_args():
 
 
 #
-def process(args, session, input_csv, output_file):
+def process(args, session, input_json, output_file):
 
     # hold json in memory
     data = []
     # should use the following but the documentation doesn't include pagination details
     # aviaryApi.get_collection_list(args, session)
     # aviaryApi.get_collection_resources(args, session, collection['id'])
-    for i, resource in enumerate(input_csv):
-        try:
-            item = aviaryApi.get_resource_item(args, session, resource['aviary ID'])
-            data.append(json.loads(item))
-        except BaseException as e:
-            logging.error(f"{e} \n{resource}")
-            # add a line to the CSV output with the error
-        sleep(args.wait)
+    for i, resource in enumerate(input_json):
+        logging.info(f"{resource['data']['media_file_id']}")
+        for j, media_file_id in enumerate(resource['data']['media_file_id']):
+            try:
+                item = aviaryApi.get_media_item(args, session, media_file_id)
+                data.append(json.loads(item))
+            except BaseException as e:
+                logging.error(f"{e} \n{media_file_id}")
+                # add a line to the CSV output with the error
+            if j >= 10:
+                logging.warning(f"Check number of media files - this workaround may miss items as 'media_file_id' property may limit to only 10.\n{item}")
+            sleep(args.wait)
         aviaryUtilities.progressIndicator(i, args.logging_level)
     output_file.write(json.dumps(data))
     print(f"\nItems processed: {i + 1}")
@@ -65,10 +69,10 @@ def main():
 
     session = aviaryApi.init_session(args, username, password)
 
-    with open(args.input, 'r', encoding="utf-8", newline='') as input_file:
-        input_csv = csv.DictReader(input_file)
+    with open(args.input, 'r', newline='') as input_file:
+        input_json = json.load(input_file)
         with open(args.output, 'wt', encoding="utf-8", newline='') as output_file:
-            process(args, session, input_csv, output_file)
+            process(args, session, input_json, output_file)
 
 
 if __name__ == "__main__":

--- a/json/aviary_api_report_resources_json_by_resource_list.py
+++ b/json/aviary_api_report_resources_json_by_resource_list.py
@@ -1,8 +1,8 @@
 ##############################################################################################
-# desc: connect to the Aviary API and get media item metadata
+# desc: connect to the Aviary API and get resource item metadata
 #       output: JSON
 #       input: CSV from the Aviary web UI resource export (API limits number of results from the collection resource listing API call with no pagination information 2023-03-27)
-#       exploritory / proof-of-concept code
+#       exploratory / proof-of-concept code
 # usage: python3 aviary_api_report_resources_json_by_resource_list.py \
 #           --server ${aviary_server_name} --output ${output_path} -input ${input_path}
 # license: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication
@@ -50,7 +50,7 @@ def process(args, session, input_csv, output_file):
         except BaseException as e:
             logging.error(f"{e} \n{resource}")
             # add a line to the CSV output with the error
-        sleep(args.wait)
+        sleep(int(args.wait))
         aviaryUtilities.progressIndicator(i, args.logging_level)
     output_file.write(json.dumps(data))
     print(f"\nItems processed: {i + 1}")

--- a/json/aviary_api_report_resources_json_by_resource_list.py
+++ b/json/aviary_api_report_resources_json_by_resource_list.py
@@ -1,0 +1,75 @@
+##############################################################################################
+# desc: connect to the Aviary API and get media item metadata
+#       output: CSV
+#       input: CSV from the Aviary web UI resource export (API limits number of results from the collection resource listing API call with no pagination information 2023-03-27)
+#       exploritory / proof-of-concept code
+# usage: python3 aviary_api_report_resources_json_by_resource_list.py \
+#           --server ${aviary_server_name} --output ${output_path} -input ${input_path}
+# license: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication
+# date: Nov, 2023
+##############################################################################################
+
+# Proof-of-concept only
+
+from getpass import getpass
+from time import sleep
+import argparse
+import csv
+import json
+import logging
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from aviary import api as aviaryApi
+from aviary import utilities as aviaryUtilities
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--server', required=True, help='Servername.')
+    parser.add_argument('--output', required=True, help='Location to store output file.')
+    parser.add_argument('--input', required=True, help='List of resource IDs to add to the report.')
+    parser.add_argument('--wait', required=False, help='Time to wait between API calls.', default=0.1)
+    parser.add_argument('--logging_level', required=False, help='Logging level.', default=logging.WARNING)
+    return parser.parse_args()
+
+
+#
+def process(args, session, input_csv, output_file):
+
+    # hold json in memory
+    data = []
+    # should use the following but the documentation doesn't include pagination details
+    # aviaryApi.get_collection_list(args, session)
+    # aviaryApi.get_collection_resources(args, session, collection['id'])
+    for i, resource in enumerate(input_csv):
+        try:
+            item = aviaryApi.get_resource_item(args, session, resource['aviary ID'])
+            data.append(json.loads(item))
+        except BaseException as e:
+            logging.error(f"{e} \n{item}")
+            # add a line to the CSV output with the error
+        sleep(args.wait)
+        aviaryUtilities.progressIndicator(i, args.logging_level)
+    output_file.write(json.dumps(data))
+    print(f"\nItems processed: {i + 1}")
+
+
+#
+def main():
+    args = parse_args()
+
+    username = input('Username:')
+    password = getpass('Password:')
+
+    session = aviaryApi.init_session(args, username, password)
+
+    with open(args.input, 'r', encoding="utf-8", newline='') as input_file:
+        input_csv = csv.DictReader(input_file)
+        with open(args.output, 'wt', encoding="utf-8", newline='') as output_file:
+            process(args, session, input_csv, output_file)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Update workarounds for the 2024-03-25 collection export
* use new indexes API GET endpoint for additional info
* replaces failing UI media CSV export with API media list builder (may truncate list to 10 media per resource)
* add index WebVTT download/export
* tweak code
* update documentation